### PR TITLE
Many small fixes

### DIFF
--- a/locations/aztec.json
+++ b/locations/aztec.json
@@ -320,7 +320,7 @@
       {
         "name": "Aztec Battle Arena (Tiny Temple: Vulture Room)",
         "access_rules": [
-          "@Angry Aztec/Aztec Lanky Vulture Shooting/Golden Banana"
+          "$templeIce, $canEnterTinyTemple, dive, $anyGun, $aztecSlam, lanky"
         ],
         "sections": [
           {

--- a/locations/caves.json
+++ b/locations/caves.json
@@ -365,7 +365,7 @@
       {
         "name": "Caves Dirt: Giant Kosha",
         "access_rules": [
-          "@Crystal Caves/Caves Chunky Transparent Igloo/Golden Banana, $port, shockwave"
+          "@Crystal Caves/Caves Chunky Transparent Igloo/Caves Chunky Transparent Igloo, $port, shockwave"
         ],
         "sections": [
           {

--- a/locations/factory.json
+++ b/locations/factory.json
@@ -245,7 +245,7 @@
       {
         "name": "Factory Fairy (Near Funky's)",
         "access_rules": [
-          "@Frantic Factory/Factory Tiny Dartboard/Golden Banana, camera"
+          "@Frantic Factory/Factory Tiny Dartboard/Factory Tiny Dartboard, camera"
         ],
         "sections": [
           {

--- a/locations/forest.json
+++ b/locations/forest.json
@@ -497,11 +497,6 @@
             "name": "Forest Tiny Anthill Banana"
           },
           {
-            "name": "Forest Tiny Bean",
-            "chest_unopened_img": "images/items/bean.png",
-            "chest_opened_img": "images/items/beanbw.png"
-          },
-          {
             "name": "Forest Anthill Enemy: Gauntlet (0)",
             "visibility_rules": [
               "dropsanity"
@@ -566,7 +561,9 @@
             ]
           },
           {
-            "name": "Forest Second Anthill Reward"
+            "name": "Forest Second Anthill Reward",
+            "chest_unopened_img": "images/items/bean.png",
+            "chest_opened_img": "images/items/beanbw.png"
           }
         ],
         "map_locations": [

--- a/locations/galleon.json
+++ b/locations/galleon.json
@@ -406,23 +406,17 @@
         "access_rules": [],
         "sections": [
           {
-            "name": "Free the Seal",
+            "name": "Galleon Donkey Free the Seal",
             "access_rules": [
               "$lighthouse, $shipyard, ^$lighthousePlatform, $blast"
             ]
           },
           {
-            "name": "Seal Race",
+            "name": "Galleon Donkey Seal Race",
             "access_rules": [
               "$lighthouse, $shipyard, ^$lighthousePlatform, $blast",
               "$shipyard, $phaseswim"
             ]
-          },
-          {
-            "name": "Galleon Donkey Free the Seal"
-          },
-          {
-            "name": "Galleon Donkey Seal Race"
           }
         ],
         "map_locations": [

--- a/locations/overview.json
+++ b/locations/overview.json
@@ -2448,8 +2448,8 @@
             "name": "Forest Tiny Anthill Banana"
           },
           {
-            "ref": "Fungi Forest/Forest Anthill/Forest Tiny Anthill Banana",
-            "name": "Forest Tiny Bean"
+            "ref": "Fungi Forest/Forest Anthill/Forest Second Anthill Reward",
+            "name": "Forest Second Anthill Reward"
           },
           {
             "ref": "Fungi Forest/Forest Tiny Spider Boss/Forest Tiny Spider Boss",

--- a/locations/overview.json
+++ b/locations/overview.json
@@ -319,7 +319,11 @@
         "sections": [
           {
             "ref": "Isles Shops/Isles Cranky/Jetpac",
-            "name": "Isles Cranky DK"
+            "name": "Jetpac"
+          },
+          {
+            "ref": "Isles Shops/Isles Cranky/Isles Cranky Donkey",
+            "name": "Isles Cranky Donkey"
           },
           {
             "ref": "Isles Shops/Isles Cranky/Isles Cranky Diddy",
@@ -3459,8 +3463,8 @@
         "name": "Castle Fairies",
         "sections": [
           {
-            "ref": "Creepy Castle/Inside the Tree/Castle Donkey Tree Sniping",
-            "name": "Castle Fairy (Tree Sniping Room)"
+            "ref": "Creepy Castle/Inside the Tree/Castle Fairy (Tree Sniper Room)",
+            "name": "Castle Fairy (Tree Sniper Room)"
           },
           {
             "ref": "Creepy Castle/Castle Fairy (Near Car Race)/Castle Fairy (Near Car Race)",

--- a/locations/shops.json
+++ b/locations/shops.json
@@ -658,7 +658,7 @@
             ]
           },
           {
-            "name": "Funky Shared",
+            "name": "Factory Funky Shared",
             "access_rules": [
               "funky"
             ],

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -877,7 +877,7 @@ function castleSlam()
     if has("blueslam") and (has("l5_castle") or has("l6_castle")) then
       return true
     end
-    if has("redslam") and (has("l7_castle") or has("l8_slam")) then
+    if has("redslam") and (has("l7_castle") or has("l8_castle")) then
       return true
     end
     return false


### PR DESCRIPTION
* Factory Fairy near Funky now correctly requires Dartboard logic
* Jetpac is now correctly labeled instead of showing up as Isles Cranky DK, and Isles Cranky DK has been re-added to the overview
* Castle Tree Sniping Fairy on overview is now correctly tied to the fairy instead of the GB
* Seal Race locations have been de-duplicated
* De-duplicated the Forest Second Anthill Reward
* Fixed an issue where Level 8 Castle did not properly account for slams
* Fixed Kosha Dirt logic to account for doing Chunky Transparent Igloo first
* Fixed Aztec Arena logic so it actually works